### PR TITLE
Fix tests for human readable IDs

### DIFF
--- a/tests/check-ids.test.ts
+++ b/tests/check-ids.test.ts
@@ -16,6 +16,7 @@ describe("ID Display Verification", () => {
 
     // Check if the result contains human-readable Item ID (like TCON-147)
     const hasItemId = result.content[0].text.includes("Item ID:");
+    expect(hasItemId).toBe(true);
     console.log("getMyItems output sample:", result.content[0].text);
     console.log("Contains human-readable Item ID:", hasItemId);
   });
@@ -52,6 +53,7 @@ describe("ID Display Verification", () => {
 
     // Check if the result contains human-readable Item ID (like TCON-147)
     const hasItemId = result.content[0].text.includes("Item ID:");
+    expect(hasItemId).toBe(true);
     console.log("addTask output sample:", result.content[0].text);
     console.log("Contains human-readable Item ID:", hasItemId);
   });


### PR DESCRIPTION
## Summary
- assert that human-readable item IDs appear in check-ids test

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_684372d5887483219da05d085a7e39ed